### PR TITLE
Always return a db type even if its not handled

### DIFF
--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/geckoboard/go-mssqldb/internal/cp"
@@ -1114,7 +1115,7 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 	case typeVariant:
 		return reflect.TypeOf(nil)
 	default:
-		panic(fmt.Sprintf("not implemented makeGoLangScanType for type %d", ti.TypeId))
+		return reflect.TypeOf(nil)
 	}
 }
 
@@ -1236,7 +1237,7 @@ func makeDecl(ti typeInfo) string {
 		}
 		return fmt.Sprintf("%s READONLY", ti.UdtInfo.TypeName)
 	default:
-		panic(fmt.Sprintf("not implemented makeDecl for type %#x", ti.TypeId))
+		return "unhandled"
 	}
 }
 
@@ -1342,8 +1343,10 @@ func makeGoLangTypeName(ti typeInfo) string {
 		return "SQL_VARIANT"
 	case typeBigBinary:
 		return "BINARY"
+	case typeUdt:
+		return strings.ToUpper(ti.UdtInfo.TypeName)
 	default:
-		panic(fmt.Sprintf("not implemented makeGoLangTypeName for type %d", ti.TypeId))
+		return "UNHANDLED"
 	}
 }
 
@@ -1466,7 +1469,7 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 	case typeBigBinary:
 		return int64(ti.Size), true
 	default:
-		panic(fmt.Sprintf("not implemented makeGoLangTypeLength for type %d", ti.TypeId))
+		return 0, false
 	}
 }
 
@@ -1577,6 +1580,6 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 	case typeBigBinary:
 		return 0, 0, false
 	default:
-		panic(fmt.Sprintf("not implemented makeGoLangTypePrecisionScale for type %d", ti.TypeId))
+		return 0, 0, false
 	}
 }


### PR DESCRIPTION
This changes the some return values which are used to build column type metadata when calling sql.DB#ColumnTypes()

Previously if a query returned a user defined type then it would panic, because these types are not implemented by the library... As we also don't plan to support user defined types, instead of panic we return the name the user defined info type name or "UNHANDLED" if the type is completely unknown (although al other types as I understand fall under the udt).

So in the case of geometry and geography types it will now return "GEOMETRY" and "GEOGRAPHY" respectively and should work with custom types as well.

We also for the other column metadata now return 0 by default for the precision and scale and return a scanType of nil always.